### PR TITLE
[feat] 레이아웃 구성

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -1,10 +1,15 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
 import App from './index';
 
 describe('App 컴포넌트', () => {
   it('렌더링이 올바르게 된다', () => {
+    (useRecoilValue as jest.Mock).mockImplementation(({ key }) =>
+      key === 'toastsState' ? [] : null,
+    );
+
     const { container } = render(<App />);
 
     expect(container).not.toBeNull();

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { wrapper } from '@tests/functions';
+
+import Layout from './index';
+
+describe('Layout 컴포넌트', () => {
+  it('렌더링이 올바르게 된다', async () => {
+    const { queryAllByText } = render(
+      <MemoryRouter initialEntries={['/trainings']}>
+        <Layout />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+    expect(queryAllByText('운동종목')).toHaveLength(2);
+  });
+});

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,123 @@
+import {
+  Menu as MenuIcon,
+  ChevronLeft as ChevronLeftIcon,
+  Dashboard as DashboardIcon,
+} from '@mui/icons-material';
+import {
+  Box,
+  Toolbar,
+  List,
+  Typography,
+  Divider,
+  IconButton,
+  Container,
+  Paper,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
+import UserMenu from '@src/components/UserMenu';
+
+import { AppBar, Drawer } from './styled';
+
+const Layout: React.FC = () => {
+  const [open, setOpen] = useState<boolean>(true);
+  const { pathname } = useLocation();
+  const title = useMemo(() => {
+    switch (pathname) {
+      case '/trainings':
+        return '운동종목';
+      default:
+        return '';
+    }
+  }, [pathname]);
+
+  const toggleDrawer = () => setOpen(prevOpen => !prevOpen);
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <AppBar position="absolute" open={open}>
+        <Toolbar sx={{ pr: '24px' }}>
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="open drawer"
+            onClick={toggleDrawer}
+            sx={{
+              marginRight: '36px',
+              ...(open && { display: 'none' }),
+            }}
+          >
+            <MenuIcon />
+          </IconButton>
+
+          <Typography
+            component="h1"
+            variant="h6"
+            color="inherit"
+            noWrap
+            sx={{ flexGrow: 1, fontWeight: 'bold' }}
+          >
+            {title}
+          </Typography>
+
+          <UserMenu />
+        </Toolbar>
+      </AppBar>
+
+      <Drawer variant="permanent" open={open}>
+        <Toolbar
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            px: [1],
+          }}
+        >
+          <IconButton onClick={toggleDrawer}>
+            <ChevronLeftIcon />
+          </IconButton>
+        </Toolbar>
+        <Divider />
+        <List component="nav">
+          <ListItemButton
+            to="/trainings"
+            component={Link}
+            selected={pathname === '/trainings'}
+          >
+            <ListItemIcon>
+              <DashboardIcon />
+            </ListItemIcon>
+            <ListItemText primary="운동종목" />
+          </ListItemButton>
+        </List>
+      </Drawer>
+
+      <Box
+        component="main"
+        sx={{
+          backgroundColor: theme =>
+            theme.palette.mode === 'light'
+              ? theme.palette.grey[100]
+              : theme.palette.grey[900],
+          flexGrow: 1,
+          height: '100vh',
+          overflow: 'auto',
+        }}
+      >
+        <Toolbar />
+
+        <Container maxWidth={false} sx={{ my: 4 }}>
+          <Paper sx={{ p: 2 }}>
+            <Outlet />
+          </Paper>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default Layout;

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -1,0 +1,48 @@
+import { AppBar as MuiAppBar, Drawer as MuiDrawer } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const drawerWidth = 240;
+
+export const AppBar = styled(MuiAppBar, {
+  shouldForwardProp: prop => prop !== 'open',
+})<{ open: boolean }>(({ theme, open }) => ({
+  zIndex: theme.zIndex.drawer + 1,
+  transition: theme.transitions.create(['width', 'margin'], {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  ...(open && {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  }),
+}));
+
+export const Drawer = styled(MuiDrawer, {
+  shouldForwardProp: prop => prop !== 'open',
+})(({ theme, open }) => ({
+  '& .MuiDrawer-paper': {
+    position: 'relative',
+    whiteSpace: 'nowrap',
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    boxSizing: 'border-box',
+    ...(!open && {
+      overflowX: 'hidden',
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      width: theme.spacing(7),
+      [theme.breakpoints.up('sm')]: {
+        width: theme.spacing(9),
+      },
+    }),
+  },
+}));

--- a/src/components/Routes/index.tsx
+++ b/src/components/Routes/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes as ReactRouterRoutes } from 'react-router-dom';
 
+import Layout from '@src/components/Layout';
 import Administrator from '@src/components/Routes/middlewares/Administrator';
 import RedirectIfAdministrator from '@src/components/Routes/middlewares/RedirectIfAdministrator';
 import CreateTrainingsScreen from '@src/screens/CreateTrainingsScreen';
@@ -12,6 +13,7 @@ const Routes: React.FC = () => {
   return (
     <ReactRouterRoutes>
       <Route path="*" element={<NotFoundScreen />} />
+
       <Route
         path="/login"
         element={
@@ -20,22 +22,18 @@ const Routes: React.FC = () => {
           </RedirectIfAdministrator>
         }
       />
+
       <Route
-        path="/trainings"
+        path="/"
         element={
           <Administrator>
-            <TrainingsScreen />
+            <Layout />
           </Administrator>
         }
-      />
-      <Route
-        path="/trainings/create"
-        element={
-          <Administrator>
-            <CreateTrainingsScreen />
-          </Administrator>
-        }
-      />
+      >
+        <Route path="trainings" element={<TrainingsScreen />} />
+        <Route path="trainings/create" element={<CreateTrainingsScreen />} />
+      </Route>
     </ReactRouterRoutes>
   );
 };

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -21,7 +21,7 @@ const Toast: React.FC<ToastProps & { index: number }> = ({
       open={open}
       autoHideDuration={3000}
       onClose={handleClose}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       TransitionProps={{ onExited: handleExited }}
     >
       <Alert severity={severity} sx={{ width: '100%' }} onClose={handleClose}>

--- a/src/components/UserMenu/UserMenu.test.tsx
+++ b/src/components/UserMenu/UserMenu.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { wrapper } from '@tests/functions';
+
+import UserMenu from './index';
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useRecoilValue: jest.fn(),
+}));
+
+describe('UserMenu 컴포넌트', () => {
+  const name = 'John';
+  const rendered = () =>
+    render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>,
+      { wrapper },
+    );
+
+  beforeEach(() => {
+    (useRecoilValue as jest.Mock).mockImplementation(({ key }) =>
+      key === 'userSelector' ? { name } : null,
+    );
+  });
+
+  it('렌더링이 올바르게 된다', () => {
+    const { queryByText } = rendered();
+
+    expect(queryByText(name)).not.toBeNull();
+  });
+
+  it('사용자 이름을 클릭하면 로그아웃 버튼이 보인다', () => {
+    const { getByText, queryByText } = rendered();
+
+    fireEvent.click(getByText(name));
+
+    expect(queryByText('로그아웃')).not.toBeNull();
+  });
+
+  it('로그아웃 버튼을 누르면 로그아웃 된다', () => {
+    sessionStorage.setItem('@token', 'loginned');
+    const { getByText } = rendered();
+
+    fireEvent.click(getByText(name));
+    fireEvent.click(getByText('로그아웃'));
+
+    expect(sessionStorage.getItem('@token')).toBeNull();
+  });
+});

--- a/src/components/UserMenu/index.tsx
+++ b/src/components/UserMenu/index.tsx
@@ -1,0 +1,53 @@
+import { Person as PersonIcon } from '@mui/icons-material';
+import { Button, Menu, MenuItem } from '@mui/material';
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import useLogout from '@src/hooks/useLogout';
+import { userSelector } from '@src/recoils';
+
+const UserMenu: React.FC = () => {
+  const user = useRecoilValue(userSelector);
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const open = Boolean(anchorEl);
+  const logout = useLogout();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        id="user-button"
+        aria-controls={open ? 'user-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        color="inherit"
+        variant="outlined"
+        startIcon={<PersonIcon />}
+      >
+        {user?.name}
+      </Button>
+
+      <Menu
+        id="user-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'user-button',
+        }}
+      >
+        <MenuItem onClick={logout}>로그아웃</MenuItem>
+      </Menu>
+    </div>
+  );
+};
+
+export default UserMenu;

--- a/src/screens/LoginScreen/LoginScreen.test.tsx
+++ b/src/screens/LoginScreen/LoginScreen.test.tsx
@@ -12,6 +12,8 @@ import { JWTTokenState, toastsState } from '@src/recoils';
 import LoginScreen from '@src/screens/LoginScreen/index';
 import { userFactory, wrapper } from '@tests/functions';
 
+jest.unmock('recoil');
+
 describe('LoginScreen 컴포넌트', () => {
   const input = {
     email: 'john@example.com',

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useRecoilValue: jest.fn(),
+}));


### PR DESCRIPTION
### 작업 개요
헤더 및 사이드 메뉴로 레이아웃을 구성

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- [mui dashboard template](https://github.com/mui/material-ui/tree/v5.6.2/docs/data/material/getting-started/templates/dashboard) 그대로 사용
- `recoils` 글로벌 mocking

resolve #41

