### PR TITLE
[feat] 이메일 인증 페이지 및 기능 구현

### DIFF
--- a/introspection.json
+++ b/introspection.json
@@ -751,14 +751,14 @@
             "description": "사용자 이메일 인증",
             "args": [
               {
-                "name": "input",
+                "name": "token",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "VerifyInput",
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -767,6 +767,18 @@
                 "deprecationReason": null
               }
             ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Boolean", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "withdrawal",
+            "description": "사용자 삭제",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1824,41 +1836,6 @@
         "interfaces": [
           { "kind": "INTERFACE", "name": "Model", "ofType": null }
         ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "VerifyInput",
-        "description": "사용자 이메일 인증 입력 객체",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "email",
-            "description": "이메일",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "emailVerifyToken",
-            "description": "이메일 인증 토큰",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/introspection.json.graphql
+++ b/introspection.json.graphql
@@ -53,7 +53,9 @@ type Mutation {
     "운동종목 수정"
     updateTraining(_id: ObjectId!, input: UpdateTrainingInput!): Boolean!
     "사용자 이메일 인증"
-    verify(input: VerifyInput!): Boolean!
+    verify(token: String!): Boolean!
+    "사용자 삭제"
+    withdrawal: Boolean!
 }
 
 "운동계획 모델"
@@ -302,14 +304,6 @@ input UpdateTrainingInput {
     type: TrainingType
     "운동영상 경로"
     videoPath: String
-}
-
-"사용자 이메일 인증 입력 객체"
-input VerifyInput {
-    "이메일"
-    email: String!
-    "이메일 인증 토큰"
-    emailVerifyToken: String!
 }
 
 "볼륨 입력 객체"

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -2,8 +2,9 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import Footer from '@src/components/Footer/index';
 import { wrapper } from '@tests/functions';
+
+import Footer from './index';
 
 describe('Footer 컴포넌트', () => {
   it('렌더링이 올바르게 된다', () => {

--- a/src/components/Routes/index.tsx
+++ b/src/components/Routes/index.tsx
@@ -5,6 +5,7 @@ import Layout from '@src/components/Layout';
 import Administrator from '@src/components/Routes/middlewares/Administrator';
 import RedirectIfAdministrator from '@src/components/Routes/middlewares/RedirectIfAdministrator';
 import CreateTrainingsScreen from '@src/screens/CreateTrainingsScreen';
+import EmailVerifyScreen from '@src/screens/EmailVerifyScreen';
 import HomeScreen from '@src/screens/HomeScreen';
 import LoginScreen from '@src/screens/LoginScreen';
 import NotFoundScreen from '@src/screens/NotFoundScreen';
@@ -23,6 +24,7 @@ const Routes: React.FC = () => {
       <Route element={<RedirectIfAdministrator />}>
         <Route path="/login" element={<LoginScreen />} />
         <Route path="/oauth/naver" element={<LoginScreen />} />
+        <Route path="/email/verify" element={<EmailVerifyScreen />} />
       </Route>
 
       <Route

--- a/src/operations/mutations/verify.ts
+++ b/src/operations/mutations/verify.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export const VERIFY = gql`
+  mutation verify($token: String!) {
+    verify(token: $token)
+  }
+`;

--- a/src/screens/EmailVerifyScreen/EmailVerifyScreen.test.tsx
+++ b/src/screens/EmailVerifyScreen/EmailVerifyScreen.test.tsx
@@ -1,0 +1,41 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { MockedResponse } from '@apollo/client/testing/core';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { VERIFY } from '@src/operations/mutations/verify';
+import { wrapper } from '@tests/functions';
+
+import EmailVerifyScreen from './index';
+
+describe('EmailVerifyScreen 컴포넌트', () => {
+  const token = 'token';
+  const mocks: ReadonlyArray<MockedResponse> = [
+    {
+      request: {
+        query: VERIFY,
+        variables: { token },
+      },
+      result: {
+        data: { verify: true },
+      },
+    },
+  ];
+  const rendered = () =>
+    render(
+      <MockedProvider mocks={mocks}>
+        <MemoryRouter initialEntries={[`/email/verify?token=${token}`]}>
+          <EmailVerifyScreen />
+        </MemoryRouter>
+      </MockedProvider>,
+      { wrapper },
+    );
+
+  it('렌더링이 올바르게 된다', async () => {
+    const { findByText } = rendered();
+
+    expect(await findByText('이메일이 인증 되었습니다!')).toBeInTheDocument();
+    expect(await findByText('홈으로 돌아가기')).toBeInTheDocument();
+  });
+});

--- a/src/screens/EmailVerifyScreen/hooks/useVerify.ts
+++ b/src/screens/EmailVerifyScreen/hooks/useVerify.ts
@@ -1,0 +1,53 @@
+import { useMutation } from '@apollo/client';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { VERIFY } from '@src/operations/mutations/verify';
+import { Mutation, MutationVerifyArgs } from '@src/types/graphql';
+
+const useVerify = () => {
+  const [searchParams] = useSearchParams();
+  const [verify, { data, error }] = useMutation<
+    Pick<Mutation, 'verify'>,
+    MutationVerifyArgs
+  >(VERIFY);
+  const [result, setResult] = useState<'success' | 'failed'>();
+  const isSuccess = useMemo(() => result === 'success', [result]);
+
+  useEffect(() => {
+    (async () => {
+      const token = searchParams.get('token');
+
+      if (!token) {
+        setResult('failed');
+      } else {
+        await verify({
+          variables: {
+            token,
+          },
+        });
+      }
+    })();
+  }, [searchParams, verify]);
+
+  useEffect(() => {
+    if (data?.verify) {
+      setResult('success');
+    } else {
+      setResult('failed');
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (error) {
+      setResult('failed');
+    }
+  }, [error]);
+
+  return {
+    isLoading: result === undefined,
+    isSuccess,
+  };
+};
+
+export default useVerify;

--- a/src/screens/EmailVerifyScreen/index.tsx
+++ b/src/screens/EmailVerifyScreen/index.tsx
@@ -1,0 +1,81 @@
+import { Close as CloseIcon, Check as CheckIcon } from '@mui/icons-material';
+import {
+  Avatar,
+  Box,
+  Button,
+  Container,
+  Divider,
+  Link,
+  Paper,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import { Link as ReactRouterLink } from 'react-router-dom';
+
+import Loader from '@src/components/Loader';
+
+import useVerify from './hooks/useVerify';
+
+const EmailVerifyScreen: React.FC = () => {
+  const { isLoading, isSuccess } = useVerify();
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <Container component="main" maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper elevation={3} sx={{ p: 3 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <Avatar
+            sx={{ mb: 1, bgcolor: isSuccess ? 'primary.main' : 'error.main' }}
+          >
+            {isSuccess ? (
+              <CheckIcon fontSize="small" />
+            ) : (
+              <CloseIcon fontSize="small" />
+            )}
+          </Avatar>
+          <Typography variant="h6">
+            {isSuccess
+              ? '이메일이 인증 되었습니다!'
+              : '이메일 인증에 실패했습니다..'}
+          </Typography>
+        </Box>
+
+        <Divider sx={{ mt: 1, mb: 2 }} />
+
+        <Typography variant="body2">
+          {isSuccess
+            ? '근육맨 서비스를 마음껏 즐겨보세요!'
+            : '유효하지 않은 링크로 접속하신거 같아요.'}
+          <br />
+          도움이 필요하시다면{' '}
+          <Link href="mailto:muscleman@muscleman.kr">여기</Link>
+          로 메일을 보내주세요. <br />
+          최대한 빠르게 도움을 드릴 수 있도록 노력하겠습니다!!! 💪
+        </Typography>
+
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+          <Button
+            to="/"
+            variant="contained"
+            color={isSuccess ? 'primary' : 'error'}
+            sx={{ mx: 'auto' }}
+            component={ReactRouterLink}
+          >
+            홈으로 돌아가기
+          </Button>
+        </Box>
+      </Paper>
+    </Container>
+  );
+};
+
+export default EmailVerifyScreen;

--- a/src/screens/LoginScreen/index.tsx
+++ b/src/screens/LoginScreen/index.tsx
@@ -64,7 +64,7 @@ const LoginScreen: React.FC = () => {
     <Container data-testid="loginScreen" component="main" maxWidth="xs">
       <Box
         sx={{
-          marginTop: 8,
+          mt: 8,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -74,6 +74,7 @@ export type Mutation = {
   socialLogin: AuthenticationResponse;
   updateTraining: Scalars['Boolean'];
   verify: Scalars['Boolean'];
+  withdrawal: Scalars['Boolean'];
 };
 
 export type MutationCreateTrainingArgs = {
@@ -119,7 +120,7 @@ export type MutationUpdateTrainingArgs = {
 };
 
 export type MutationVerifyArgs = {
-  input: VerifyInput;
+  token: Scalars['String'];
 };
 
 export type Plan = Model & {
@@ -250,11 +251,6 @@ export type User = Model & {
   roles?: Maybe<Array<Role>>;
   tel?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
-};
-
-export type VerifyInput = {
-  email: Scalars['String'];
-  emailVerifyToken: Scalars['String'];
 };
 
 export type Volume = Model & {


### PR DESCRIPTION
### 작업 개요
- 이메일 인증 페이지 생성 및 기능 구현

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- api 최신화
- `EmailVerifyScreen` 컴포넌트 생성
- `/email/verify` 페이지 접속시 query string의 `token` 값 확인하여 api 호출. 결과값에 따라 렌더링 분기 
- 관련 테스트 작성

resolve #62

