### PR TITLE
[Feat] 비밀번호 초기화 페이지 생성 및 GraphQL 연동

### DIFF
--- a/introspection.json
+++ b/introspection.json
@@ -350,6 +350,7 @@
         "enumValues": null,
         "possibleTypes": [
           { "kind": "OBJECT", "name": "Plan", "ofType": null },
+          { "kind": "OBJECT", "name": "ResetPassword", "ofType": null },
           { "kind": "OBJECT", "name": "Training", "ofType": null },
           { "kind": "OBJECT", "name": "User", "ofType": null },
           { "kind": "OBJECT", "name": "Volume", "ofType": null }
@@ -360,6 +361,51 @@
         "name": "Mutation",
         "description": null,
         "fields": [
+          {
+            "name": "changePassword",
+            "description": "비밀번호 변경",
+            "args": [
+              {
+                "name": "password",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "token",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Boolean", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "createTraining",
             "description": "운동종목 추가",
@@ -431,6 +477,35 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "ObjectId",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "Boolean", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "findPassword",
+            "description": "비밀번호 변경 이메일 전송 및 토큰 할당",
+            "args": [
+              {
+                "name": "email",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -1244,6 +1319,79 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ResetPassword",
+        "description": "비밀번호 초기화 모델",
+        "fields": [
+          {
+            "name": "_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "DateTime", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": "이메일",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "token",
+            "description": "비밀번호 초기화 토큰",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "DateTime", "ofType": null }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          { "kind": "INTERFACE", "name": "Model", "ofType": null }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/introspection.json.graphql
+++ b/introspection.json.graphql
@@ -30,12 +30,16 @@ type JWTResponse {
 }
 
 type Mutation {
+    "비밀번호 변경"
+    changePassword(password: String!, token: String!): Boolean!
     "운동종목 추가"
     createTraining(input: CreateTrainingInput!): Training!
     "운동계획 삭제"
     deletePlan(_id: ObjectId!): Boolean!
     "운동종목 삭제"
     deleteTraining(_id: ObjectId!): Boolean!
+    "비밀번호 변경 이메일 전송 및 토큰 할당"
+    findPassword(email: String!): Boolean!
     "사용자 JWT 토큰 반환"
     login(input: LoginInput!): AuthenticationResponse!
     "여러개의 운동 계획 생성 및 수정"
@@ -86,6 +90,17 @@ type Query {
     trainings: [Training!]!
     "모든 사용자 조회"
     users: [User!]!
+}
+
+"비밀번호 초기화 모델"
+type ResetPassword implements Model {
+    _id: ID!
+    createdAt: DateTime!
+    "이메일"
+    email: String!
+    "비밀번호 초기화 토큰"
+    token: String!
+    updatedAt: DateTime!
 }
 
 "운동종목 모델"

--- a/src/components/Routes/index.tsx
+++ b/src/components/Routes/index.tsx
@@ -26,7 +26,7 @@ const Routes: React.FC = () => {
         <Route path="/login" element={<LoginScreen />} />
         <Route path="/oauth/naver" element={<LoginScreen />} />
         <Route path="/email/verify" element={<EmailVerifyScreen />} />
-        <Route path="/changepassword" element={<ChangePasswordScreen />} />
+        <Route path="/password/reset" element={<ChangePasswordScreen />} />
       </Route>
 
       <Route

--- a/src/components/Routes/index.tsx
+++ b/src/components/Routes/index.tsx
@@ -4,6 +4,7 @@ import { Route, Routes as ReactRouterRoutes } from 'react-router-dom';
 import Layout from '@src/components/Layout';
 import Administrator from '@src/components/Routes/middlewares/Administrator';
 import RedirectIfAdministrator from '@src/components/Routes/middlewares/RedirectIfAdministrator';
+import ChangePasswordScreen from '@src/screens/ChangePasswordScreen';
 import CreateTrainingsScreen from '@src/screens/CreateTrainingsScreen';
 import EmailVerifyScreen from '@src/screens/EmailVerifyScreen';
 import HomeScreen from '@src/screens/HomeScreen';
@@ -25,6 +26,7 @@ const Routes: React.FC = () => {
         <Route path="/login" element={<LoginScreen />} />
         <Route path="/oauth/naver" element={<LoginScreen />} />
         <Route path="/email/verify" element={<EmailVerifyScreen />} />
+        <Route path="/changepassword" element={<ChangePasswordScreen />} />
       </Route>
 
       <Route

--- a/src/operations/mutations/changePassword.ts
+++ b/src/operations/mutations/changePassword.ts
@@ -1,41 +1,30 @@
 import { gql, useMutation } from '@apollo/client';
-import { Dispatch, SetStateAction } from 'react';
 import { useSetRecoilState } from 'recoil';
 
-import { AUTHENTICATION_RESPONSE_FIELDS } from '@src/fragments/user';
 import { toastsState } from '@src/recoils';
 import { Mutation, MutationChangePasswordArgs } from '@src/types/graphql';
 
 export const CHANGE_PASSWORD = gql`
-  ${AUTHENTICATION_RESPONSE_FIELDS}
   mutation changePassword($password: String!, $token: String!) {
     changePassword(password: $password, token: $token)
   }
 `;
 
-const useChangePassword = (
-  setErrorMessages: Dispatch<SetStateAction<string[]>>,
-) => {
+const useChangePassword = () => {
   const setToast = useSetRecoilState(toastsState);
   const [changePassword] = useMutation<
     Pick<Mutation, 'changePassword'>,
     MutationChangePasswordArgs
   >(CHANGE_PASSWORD, {
     onError: error => {
-      setErrorMessages(
-        error?.graphQLErrors
-          .map(e => {
-            setToast(prevState =>
-              prevState.concat({
-                message: e.message,
-                severity: 'error',
-              }),
-            );
-
-            return '';
-          })
-          .filter(message => message) || [],
-      );
+      error?.graphQLErrors.forEach(e => {
+        setToast(prevState =>
+          prevState.concat({
+            message: e.message,
+            severity: 'error',
+          }),
+        );
+      });
     },
   });
 

--- a/src/operations/mutations/resetPassword.ts
+++ b/src/operations/mutations/resetPassword.ts
@@ -1,0 +1,45 @@
+import { gql, useMutation } from '@apollo/client';
+import { Dispatch, SetStateAction } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { AUTHENTICATION_RESPONSE_FIELDS } from '@src/fragments/user';
+import { toastsState } from '@src/recoils';
+import { Mutation, MutationChangePasswordArgs } from '@src/types/graphql';
+
+export const CHANGE_PASSWORD = gql`
+  ${AUTHENTICATION_RESPONSE_FIELDS}
+  mutation changePassword($password: String!, $token: String!) {
+    changePassword(password: $password, token: $token)
+  }
+`;
+
+const useChangePassword = (
+  setErrorMessages: Dispatch<SetStateAction<string[]>>,
+) => {
+  const setToast = useSetRecoilState(toastsState);
+  const [changePassword] = useMutation<
+    Pick<Mutation, 'changePassword'>,
+    MutationChangePasswordArgs
+  >(CHANGE_PASSWORD, {
+    onError: error => {
+      setErrorMessages(
+        error?.graphQLErrors
+          .map(e => {
+            setToast(prevState =>
+              prevState.concat({
+                message: e.message,
+                severity: 'error',
+              }),
+            );
+
+            return '';
+          })
+          .filter(message => message) || [],
+      );
+    },
+  });
+
+  return changePassword;
+};
+
+export default useChangePassword;

--- a/src/screens/ChangePasswordScreen/hooks/usePasswordRules.ts
+++ b/src/screens/ChangePasswordScreen/hooks/usePasswordRules.ts
@@ -1,9 +1,10 @@
 import { RegisterOptions } from 'react-hook-form';
+import { UseFormGetValues } from 'react-hook-form/dist/types/form';
 
 import { ChangePasswordFormInput } from '@src/screens/ChangePasswordScreen';
 
 const usePasswordRules = (
-  validatePassword: () => boolean,
+  getValues: UseFormGetValues<ChangePasswordFormInput>,
 ): {
   passwordRules: RegisterOptions<ChangePasswordFormInput, 'password'>;
   passwordConfirmationRules: RegisterOptions<
@@ -19,7 +20,8 @@ const usePasswordRules = (
     },
   },
   passwordConfirmationRules: {
-    validate: validatePassword,
+    validate: value =>
+      value === getValues('password') || '비밀번호와 값이 다릅니다',
   },
 });
 

--- a/src/screens/ChangePasswordScreen/hooks/usePasswordRules.ts
+++ b/src/screens/ChangePasswordScreen/hooks/usePasswordRules.ts
@@ -1,0 +1,26 @@
+import { RegisterOptions } from 'react-hook-form';
+
+import { ChangePasswordFormInput } from '@src/screens/ChangePasswordScreen';
+
+const usePasswordRules = (
+  validatePassword: () => boolean,
+): {
+  passwordRules: RegisterOptions<ChangePasswordFormInput, 'password'>;
+  passwordConfirmationRules: RegisterOptions<
+    ChangePasswordFormInput,
+    'passwordConfirmation'
+  >;
+} => ({
+  passwordRules: {
+    required: '비밀번호를 입력해주세요',
+    minLength: {
+      value: 8,
+      message: '8글자보다 적습니다',
+    },
+  },
+  passwordConfirmationRules: {
+    validate: validatePassword,
+  },
+});
+
+export default usePasswordRules;

--- a/src/screens/ChangePasswordScreen/index.tsx
+++ b/src/screens/ChangePasswordScreen/index.tsx
@@ -1,0 +1,114 @@
+import { LockOutlined as LockOutlinedIcon } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
+import { Avatar, Box, Container, TextField, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
+
+import useChangePassword from '@src/operations/mutations/resetPassword';
+import usePasswordRules from '@src/screens/ChangePasswordScreen/hooks/usePasswordRules';
+
+export type ChangePasswordFormInput = {
+  password: string;
+  passwordConfirmation: string;
+};
+
+const ChangePasswordScreen: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    getValues,
+  } = useForm<ChangePasswordFormInput>();
+  const [errorMessages, setErrorMessages] = useState<string[]>([]);
+  const changePassword = useChangePassword(setErrorMessages);
+
+  const validatePassword = (): boolean => {
+    return getValues('password') === getValues('passwordConfirmation');
+  };
+
+  const { passwordRules, passwordConfirmationRules } =
+    usePasswordRules(validatePassword);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const onSubmit = async ({ password }: ChangePasswordFormInput) => {
+    await changePassword({
+      variables: {
+        token: searchParams.get('token') || '',
+        password,
+      },
+    });
+  };
+
+  return (
+    <Container data-testid="loginScreen" component="main" maxWidth="xs">
+      <Box
+        sx={{
+          mt: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Avatar sx={{ m: 1, bgcolor: 'primary.main' }}>
+          <LockOutlinedIcon />
+        </Avatar>
+        <Typography component="h5" variant="h5" sx={{ fontWeight: 'bold' }}>
+          비밀번호 변경
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+          sx={{ mt: 1 }}
+        >
+          <TextField
+            error={!!errors.password}
+            margin="normal"
+            fullWidth
+            id="password"
+            label="비밀번호"
+            type="password"
+            autoComplete="new-password"
+            autoFocus
+            helperText={errors.password?.message}
+            {...register('password', passwordRules)}
+          />
+          <TextField
+            error={!!errors.passwordConfirmation}
+            margin="normal"
+            fullWidth
+            label="비밀번호 확인"
+            type="password"
+            id="password-confirmation"
+            autoComplete="new-password"
+            helperText={errors.passwordConfirmation?.message}
+            {...register('passwordConfirmation', passwordConfirmationRules)}
+          />
+          {errorMessages.map(message => (
+            <Typography
+              key={message}
+              color="error"
+              variant="body2"
+              gutterBottom={false}
+            >
+              {message}
+            </Typography>
+          ))}
+
+          <LoadingButton
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+            loading={isSubmitting}
+          >
+            비밀번호 변경
+          </LoadingButton>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default ChangePasswordScreen;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -62,9 +62,11 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  changePassword: Scalars['Boolean'];
   createTraining: Training;
   deletePlan: Scalars['Boolean'];
   deleteTraining: Scalars['Boolean'];
+  findPassword: Scalars['Boolean'];
   login: AuthenticationResponse;
   multipleCreateOrUpdatePlans: Array<Plan>;
   multipleCreateTrainings: Array<Training>;
@@ -77,6 +79,11 @@ export type Mutation = {
   withdrawal: Scalars['Boolean'];
 };
 
+export type MutationChangePasswordArgs = {
+  password: Scalars['String'];
+  token: Scalars['String'];
+};
+
 export type MutationCreateTrainingArgs = {
   input: CreateTrainingInput;
 };
@@ -87,6 +94,10 @@ export type MutationDeletePlanArgs = {
 
 export type MutationDeleteTrainingArgs = {
   _id: Scalars['ObjectId'];
+};
+
+export type MutationFindPasswordArgs = {
+  email: Scalars['String'];
 };
 
 export type MutationLoginArgs = {
@@ -171,6 +182,15 @@ export type RegisterInput = {
   passwordConfirmation: Scalars['String'];
   profileImagePath?: Maybe<Scalars['String']>;
   tel?: Maybe<Scalars['String']>;
+};
+
+export type ResetPassword = Model & {
+  __typename?: 'ResetPassword';
+  _id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  email: Scalars['String'];
+  token: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
 };
 
 export enum Role {


### PR DESCRIPTION
### 작업 개요
- 이메일 링크로 접속할 비밀번호 초기화 페이지 생성
- 패스워드 validate 추가
- validate가 통과될 경우 API 연동
- graphql 코드 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

### 생각해볼 문제
- test 코드 작성
```
  const [searchParams, setSearchParams] = useSearchParams();
```
get parameter 가져오는 부분에서 `useSearchParams` 훅을 사용하였는데 `set` 하는 함수도 기본적으로 가져와지고 있어서 사용하지 않는 함수가 선언됩니다.


resolve #63 

