### PR TITLE
[fix] 썸네일 업로드 후 label 과 겹침 & 이미지 업로드 동일한 파일명일 경우 처리

### DIFF
--- a/src/components/CreateTrainingCard/index.tsx
+++ b/src/components/CreateTrainingCard/index.tsx
@@ -1,11 +1,7 @@
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Card, CardContent, Fab, Tooltip } from '@mui/material';
 import React, { useImperativeHandle } from 'react';
-import { useForm } from 'react-hook-form';
-import {
-  SubmitErrorHandler,
-  SubmitHandler,
-} from 'react-hook-form/dist/types/form';
+import { useForm, SubmitErrorHandler, SubmitHandler } from 'react-hook-form';
 
 import TrainingFormFields from '@src/components/TrainingFormFields';
 import {
@@ -37,6 +33,7 @@ const CreateTrainingCard: React.ForwardRefRenderFunction<
     control,
     formState: { errors },
     setValue,
+    watch,
   } = useForm<CreateTrainingInput>({
     defaultValues: {
       name: '',
@@ -77,6 +74,7 @@ const CreateTrainingCard: React.ForwardRefRenderFunction<
           errors={errors}
           control={control}
           setValue={setValue}
+          watch={watch}
         />
       </CardContent>
     </Card>

--- a/src/components/EditTrainingModal/index.tsx
+++ b/src/components/EditTrainingModal/index.tsx
@@ -27,6 +27,7 @@ const EditTraningModal: React.FC = () => {
     setValue,
     control,
     formState: { errors, isSubmitting },
+    watch,
   } = useForm<UpdateTrainingInput>({
     defaultValues: {
       name: '',
@@ -71,6 +72,7 @@ const EditTraningModal: React.FC = () => {
             errors={errors}
             control={control}
             setValue={setValue}
+            watch={watch}
           />
 
           {errorMessages.map(message => (

--- a/src/components/TrainingFormFields/TrainingFormFields.test.tsx
+++ b/src/components/TrainingFormFields/TrainingFormFields.test.tsx
@@ -10,6 +10,7 @@ describe('TrainingFormFields 컴포넌트', () => {
         register={jest.fn()}
         errors={{}}
         setValue={jest.fn()}
+        watch={jest.fn()}
       />,
     );
   });

--- a/src/components/TrainingFormFields/index.tsx
+++ b/src/components/TrainingFormFields/index.tsx
@@ -11,13 +11,15 @@ import {
   Backdrop,
 } from '@mui/material';
 import React from 'react';
-import { Controller, Path } from 'react-hook-form';
-import { FieldErrors } from 'react-hook-form/dist/types/errors';
 import {
+  Controller,
+  Path,
+  FieldErrors,
   Control,
   UseFormRegister,
   UseFormSetValue,
-} from 'react-hook-form/dist/types/form';
+  UseFormWatch,
+} from 'react-hook-form';
 
 import {
   getTrainingCategoryForKorean,
@@ -40,6 +42,7 @@ type P<T> = {
   errors: FieldErrors<T>;
   control?: Control<T>;
   setValue: UseFormSetValue<T>;
+  watch: UseFormWatch<T>;
 };
 
 function TrainingFormFields<T extends TrainingInput>({
@@ -47,6 +50,7 @@ function TrainingFormFields<T extends TrainingInput>({
   errors,
   control,
   setValue,
+  watch,
 }: P<T>) {
   const {
     nameRules,
@@ -79,16 +83,14 @@ function TrainingFormFields<T extends TrainingInput>({
         label="이름"
         autoFocus
         helperText={errors.name?.message}
-        // @ts-ignore: https://github.com/react-hook-form/react-hook-form/discussions/4807
-        {...register('name', nameRules)}
+        {...register('name' as Path<T>, nameRules)}
       />
       <InputLabel id="category-label" sx={{ mt: 1 }}>
         카테고리
       </InputLabel>
       {control && (
         <Controller
-          // @ts-ignore: https://github.com/react-hook-form/react-hook-form/discussions/4807
-          name="category"
+          name={'category' as Path<T>}
           control={control}
           rules={categoryRules}
           render={({ field }) => (
@@ -113,8 +115,7 @@ function TrainingFormFields<T extends TrainingInput>({
       </InputLabel>
       {control && (
         <Controller
-          // @ts-ignore: https://github.com/react-hook-form/react-hook-form/discussions/4807
-          name="type"
+          name={'type' as Path<T>}
           control={control}
           rules={typeRules}
           render={({ field }) => (
@@ -144,8 +145,7 @@ function TrainingFormFields<T extends TrainingInput>({
         helperText={errors.description?.message}
         multiline={true}
         type="number"
-        // @ts-ignore: https://github.com/react-hook-form/react-hook-form/discussions/4807
-        {...register('description', descriptionRules)}
+        {...register('description' as Path<T>, descriptionRules)}
       />
 
       <TextField
@@ -156,12 +156,14 @@ function TrainingFormFields<T extends TrainingInput>({
         label="선호도"
         helperText={errors.preference?.message}
         type="number"
-        // @ts-ignore: https://github.com/react-hook-form/react-hook-form/discussions/4807
-        {...register('preference', preferenceRules)}
+        {...register('preference' as Path<T>, preferenceRules)}
       />
 
       <FormControl variant="outlined" margin="normal" fullWidth>
-        <InputLabel htmlFor="outlined-adornment-thumbnail">
+        <InputLabel
+          htmlFor="outlined-adornment-thumbnail"
+          shrink={!!watch('thumbnailPath' as Path<T>)}
+        >
           썸네일 경로
         </InputLabel>
         <OutlinedInput
@@ -186,12 +188,18 @@ function TrainingFormFields<T extends TrainingInput>({
             </InputAdornment>
           }
           label="썸네일 경로"
+          notched={!!watch('thumbnailPath' as Path<T>)}
           {...register('thumbnailPath' as Path<T>)}
         />
       </FormControl>
 
       <FormControl variant="outlined" margin="normal" fullWidth>
-        <InputLabel htmlFor="outlined-adornment-video">비디오 경로</InputLabel>
+        <InputLabel
+          htmlFor="outlined-adornment-video"
+          shrink={!!watch('videoPath' as Path<T>)}
+        >
+          비디오 경로
+        </InputLabel>
         <OutlinedInput
           id="outlined-adornment-video"
           type="text"
@@ -214,6 +222,7 @@ function TrainingFormFields<T extends TrainingInput>({
             </InputAdornment>
           }
           label="비디오 경로"
+          notched={!!watch('videoPath' as Path<T>)}
           {...register('videoPath' as Path<T>)}
         />
       </FormControl>

--- a/src/hooks/useBucket.ts
+++ b/src/hooks/useBucket.ts
@@ -1,11 +1,12 @@
 import AWS from 'aws-sdk';
+import dayjs from 'dayjs';
 import { ChangeEvent, useState } from 'react';
-import { Path } from 'react-hook-form';
 import {
+  Path,
   UnpackNestedValue,
   UseFormSetValue,
-} from 'react-hook-form/dist/types/form';
-import { PathValue } from 'react-hook-form/dist/types/path';
+  PathValue,
+} from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 
 import { ToastProps } from '@src/components/Toast';
@@ -39,11 +40,14 @@ const useBucket = <T extends TrainingInput>(
 
     if (target.files && target.files.length) {
       const file = target.files[0];
+      const splited = file.name.split('.');
+      const fileName = splited.slice(0, -1).join('.');
+      const extension = splited.slice(-1)[0];
 
       const upload = new AWS.S3.ManagedUpload({
         params: {
           Bucket: bucket,
-          Key: file.name,
+          Key: `${fileName}_${dayjs().format('YYYYMMDDHHmmss')}.${extension}`,
           Body: file,
         },
       });

--- a/src/hooks/useTable.ts
+++ b/src/hooks/useTable.ts
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Model } from '@src/types/graphql';
 import { Order } from '@src/types/table';
 
+// eslint-disable-next-line
 const descendingComparator = <T extends Record<string, any>>(
   a: T,
   b: T,


### PR DESCRIPTION
### 작업 개요
썸네일 업로드 후 label 과 겹침 & 이미지 업로드 동일한 파일명일 경우 처리

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `react-hook-form` 타입 해결
- `react-hook-form` import 통일
- 파일 업로드 영역 `InputLabel`의 `shrink`와 `notched`로 겹침 현상 해결
- 업로드하는 파일명에 날짜 추가

resolve #59 
resolve #65

